### PR TITLE
New changes according to the guidelines v1.2

### DIFF
--- a/vaccine-mah-manf.json
+++ b/vaccine-mah-manf.json
@@ -1,6 +1,6 @@
 {
   "valueSetId": "vaccines-covid-19-auth-holders",
-  "valueSetDate": "2021-04-27",
+  "valueSetDate": "2021-05-07",
   "valueSetValues": {
     "ORG-100001699": {
       "display": "AstraZeneca AB",
@@ -99,6 +99,13 @@
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccinemanufacturer",
       "version": "1.0"
+    },
+    "ORG-100001981": {
+      "display": "Serum Institute Of India Private Limited",
+      "lang": "en",
+      "active": true,
+      "system": "https://spor.ema.europa.eu/v1/organisations",
+      "version": ""
     }
   }
 }

--- a/vaccine-medicinal-product.json
+++ b/vaccine-medicinal-product.json
@@ -1,6 +1,6 @@
 {
   "valueSetId": "vaccines-covid-19-names",
-  "valueSetDate": "2021-04-27",
+  "valueSetDate": "2021-05-07",
   "valueSetValues": {
     "EU/1/20/1528": {
       "display": "Comirnaty",
@@ -10,7 +10,7 @@
       "version": ""
     },
     "EU/1/20/1507": {
-      "display": "COVID-19 Vaccine Moderna",
+      "display": "Spikevax (previously COVID-19 Vaccine Moderna)",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
@@ -81,6 +81,13 @@
     },
     "Covaxin": {
       "display": "Covaxin (also known as BBV152 A, B, C)",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.0"
+    },
+    "Covishield": {
+      "display": "Covishield (ChAdOx1_nCoV-19)",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",


### PR DESCRIPTION
Changes of the DCC value sets as decided by the eHN:
1. adds new entry in vaccine-mah-manf value set: Serum Institute of India
2. changes to vaccine-medicinal-product value set:
- COVID-19 Vaccine Moderna renamed to Spikevax
- adds Covishield